### PR TITLE
added install and contribution instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,56 @@
 # romancal-notebooks
 
-This repository contains jupyter notebooks for understanding how to run the Roman pipeline 
-or related issues, such as how to create a reference file.
+The notebooks in this repository demonstrate how to run the Roman pipeline (`romancal`), and related tasks such as creating reference files. There is an STScI Box folder that contains example data used in some of the notebooks. Instructions on downloading the files are contained in the relevant notebooks themselves.
 
-There is an STScI Box folder that contains example data used in some of the notebooks.
-Instructions on downloading the files are contained in the relevent notebooks themselves.
+
+## Basic Setup Instructions for Running `romancal` Notebooks
+
+Before running any of the notebooks in this repository, please run the following setup instructions. These steps will ensure you have a fresh environment for `romancal` and its dependencies, as well as Calibration Reference Database System (CRDS) set up correctly to retrieve the reference files that `romancal` uses. For the following steps, you will need to use zsh or bash.
+
+#### Step 1: Cloning the Notebook Repository
+
+You will first need to clone this repository on your machine to work with the notebooks.
+
+	1. cd into the directory where you would like these notebooks, they will be cloned into a subdirectory
+	2. In your zsh/bash shell, enter 'git clone https://github.com/spacetelescope/romancal-notebooks'
+    
+#### Step 2: CRDS Setup
+
+The Roman pipeline relies on 'reference files' for processing data. Roman reference files are stored in the Calibration Reference Database System (CRDS). Access to it is enabled by the following environment variables:
+
+	export CRDS_PATH=$HOME/crds_cache
+	export CRDS_SERVER_URL=https://roman-crds-test.stsci.edu
+
+Note that the above URL points to the TEST server which isn't publicly available but this is the way to set it up when a public server is online. The first time a reference file is accessed it is downloaded to the local cache. Subsequent uses of the file and offline access use the copy from the cache. Internally, at STScI the cache is available. For more information on CRDS consult the CRDS User Guide.
+
+#### Step 3: Creating a conda environment
+
+Create a new conda environment, called "roman-test". 
+
+** Caution: The new environment will inherit the current one. That means that if you are in the base conda environment and there are packages in it they will be available in the new environment unless you reinstall them there. This is generally bad because Python will also load packages from that base environment. A case, which is often a source for confusion, is when ipython is not installed in the new environment but is available in the base one. Starting ipython works and loading a package may work but this package is imported from the base env and most often is a version different from what's desired.)
+
+	% conda create -n roman-test python=3.9
+
+Activate the environment and install ipython and numpy
+
+	% conda activate roman-test
+	% pip install jupyter
+	% pip install numpy
+
+#### Step 4: Installing the romancal pipeline
+
+To install the latest public release of the pipeline:
+
+	% pip install romancal
+
+The correct versions of the dependencies will be pulled in. For detailed installation instructions including how to install the development version of the pipeline, or a specific version number, please see https://github.com/spacetelescope/romancal.
+
+## Contributing to the Notebooks Repository
+
+If you wish to make changes or add content to the notebooks in this repository, please:
+	1. Fork this repository to your own account. The 'fork' button is in the upper right-hand corner.
+	2. Clone your forked version to your machine.
+	3. Make a branch with a name descriptive of the changes you'll be making.
+	4. Commit these changes and push them to your remote fork.
+	5. Open a pull request on the main notebooks repository. 
+

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For additional installation instructions, please see https://github.com/spacetel
 ## Contributing to the Notebooks Repository
 
 If you wish to make changes or add content to the notebooks in this repository, please:
+
 	1. Fork this repository to your own account. The 'fork' button is in the upper right-hand corner.
 	2. Clone your forked version to your machine.
 	3. Make a branch with a name descriptive of the changes you'll be making.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,21 @@ Activate the environment and install ipython and numpy
 
 #### Step 4: Installing the romancal pipeline
 
+In most cases, you will want to install the last stable release of the pipeline. This can be done via pip.
+
 To install the latest public release of the pipeline:
 
 	% pip install romancal
 
-The correct versions of the dependencies will be pulled in. For detailed installation instructions including how to install the development version of the pipeline, or a specific version number, please see https://github.com/spacetelescope/romancal.
+The correct versions of the dependencies will be pulled in. 
+
+If you would like to install the development version of the pipeline to test recent changes, you can do that by installing the main branch of the github repository for romancal.
+
+	% pip install git+https://github.com/spacetelescope/romancal
+
+For clarity, it is a good idea to create a new environment when working with the development version of romancal with a name that indicates that the environment has the dev version installed (e.g 'romancal-dev').
+
+For additional installation instructions, please see https://github.com/spacetelescope/romancal.
 
 ## Contributing to the Notebooks Repository
 

--- a/general/Running the Roman pipeline.ipynb
+++ b/general/Running the Roman pipeline.ipynb
@@ -2,79 +2,20 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "f1b832fd",
    "metadata": {},
    "source": [
     "## Running the Roman pipeline\n",
     "\n",
-    "### Pipeline installation\n",
-    "\n",
-    "#### CRDS Setup\n",
-    "\n",
-    "Roman reference files are stored in the Calibration Reference Database System (CRDS). Access to it is enabled by the following environment variabes:\n",
-    "\n",
-    "```\n",
-    "export CRDS_PATH=$HOME/crds_cache\n",
-    "export CRDS_SERVER_URL=https://roman-crds-test.stsci.edu\n",
-    "```\n",
-    "\n",
-    "**Note** that the above URL points to the TEST server which isn't publicly available but this is the way to set it up when a public server is online. The first time a reference file is accessed it is downloaded to the local cache. Subsequent uses of the file and offline access use the copy from the cache. Internally, at STScI the cache is available. For more information on CRDS consult the [CRDS User Guide](https://jwst-crds-test.stsci.edu/static/users_guide/index.html)."
+    "##### Before running this notebook, make sure you have gone through the setup instructions on the readme for this repository to set up CRDS, create a conda environment, and install the romancal pipline in this environment.\n",
+    "This notebook shows the basic commands to run the Roman pipeline in Python."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "260f6e4d",
    "metadata": {},
    "source": [
-    "#### Install a public release of the pipeline\n",
-    "\n",
-    "This section describes installation of a released version of the pipeline.\n",
-    "\n",
-    "Create a new conda environment, called \"roman-test\".\n",
-    "(Caution Note: You need to be in zsh or bash. The new environment will inherit the current one. That means that if you are in the base conda environment and there are packages in it they will be available in the new environment unless you reinstall them there. This is generally bad because Python will also load packages from that base environment. A case, which is often a source for consfusion, is when ipython is not installed in the new environment but is available in the base one. Starting ipython owrks and loading a package may work but this package is imported from the base env and most often is a version different from what's desired.)\n",
-    "\n",
-    "```\n",
-    "% conda create -n roman-test python=3.9\n",
-    "```\n",
-    "\n",
-    "Activate the environment and install ipython and numpy\n",
-    "\n",
-    "```\n",
-    "% conda activate roman-test\n",
-    "% pip install jupyter\n",
-    "% pip install numpy\n",
-    "```\n",
-    "\n",
-    "Install the pipeline. The correct versions of the dependencies will be pulled in.\n",
-    "\n",
-    "```\n",
-    "% pip install romancal\n",
-    "```\n",
-    "\n",
-    "\n",
-    "We are ready to run the pipeline.\n",
-    "\n",
-    "#### Install a development version of the pipeline\n",
-    "\n",
-    "This section describes installation of the `main` branch of the github repository.\n",
-    "\n",
-    "Create a new conda environment, called \"roman-dev\".\n",
-    "\n",
-    "```\n",
-    "% conda create -n roman-dev python=3.9\n",
-    "```\n",
-    "\n",
-    "Activate the environment and install ipython and numpy\n",
-    "\n",
-    "```\n",
-    "% conda activate roman-dev\n",
-    "% pip install jupyter\n",
-    "% pip install numpy\n",
-    "```\n",
-    "\n",
-    "Install the pipeline\n",
-    "\n",
-    "```\n",
-    "pip install git+https://github.com/spacetelescope/romancal\n",
-    "```\n",
     "### Code development\n",
     "\n",
     "There are several packages which are concurrently developed to support the Roman pipeline calibrations.\n",
@@ -107,6 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e04669cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,6 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7d0257b7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c2291867",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,6 +86,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0aa2b471",
    "metadata": {},
    "source": [
     "This is a special data model. Science data formatting creates a Level1 (`ScienceRawModel`) file, which is the input to the pipeline. \n",
@@ -151,6 +96,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cbed5ac6",
    "metadata": {},
    "source": [
     "### Running a step using reference files in CRDS\n",
@@ -171,6 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5fd18658",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,6 +129,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "abe32779",
    "metadata": {},
    "source": [
     "In this case the output `result` is an ImageModel and can be saved to file."
@@ -190,6 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b1cc57a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,6 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f099f1a1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,6 +157,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cd5f80f1",
    "metadata": {},
    "source": [
     "### Running a step with local reference files\n",
@@ -224,6 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8a314235",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,6 +186,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e721137",
    "metadata": {},
    "source": [
     "In general, to run the pipeline from the interpreter and pass custom reference files, one needs to use an argument name \n",
@@ -250,6 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "15b62030",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,6 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "150acb13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,6 +223,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b51219de",
    "metadata": {},
    "source": [
     "In terms of code development, a \"pipeline\" is a special \"step\", which runs other steps. This means the Exposure Level Pipeline can be run in the same way as an individual step.\n",
@@ -290,18 +246,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "04aaca61",
    "metadata": {},
    "outputs": [],
    "source": [
     "stpipe list"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -320,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added some basic instructions on how to set things up for running the notebooks, and how to contribute to the notebooks repo. To avoid being redundant, I just briefly describe how to install the latest release of romancal or the main branch on github, and link to the romancal readme for more info. I think the install instructions should go in the readthedocs for roman-pipeline so they can be linked, otherwise we are just re-writing it out in multiple places.

I removed the setup info from the 'Running the Roman pipeline' notebook, and added some text. 